### PR TITLE
Don't delete custom plugins

### DIFF
--- a/push.sh
+++ b/push.sh
@@ -19,7 +19,7 @@ do
     ls -la $CLONE_DIR/$SOURCE_DIRECTORY
 done
 cp -a "$SOURCE_DIRECTORY"/. "$CLONE_DIR/$SOURCE_DIRECTORY"
-find $CLONE_DIR/$SOURCE_DIRECTORY -maxdepth 1 -mindepth 1 -type f -iname '*plugin.js' -exec rm -f {} \; # remove any custom plugins
+
 cd "$CLONE_DIR"
 
 ORIGIN_COMMIT="https://github.com/$GITHUB_REPOSITORY/commit/$GITHUB_SHA"


### PR DESCRIPTION
We've added the possibility of adding custom configuration for the docusaurus content docs in React Native using the file `reactnative-content-docs.plugin.js` which is stripped out by this line of the script.

The intention seems to be to remove these files as custom plugins shouldn't be available, even though the CLI supports them according to [it's docs](https://github.com/GetStream/stream-chat-docusaurus-cli#plugins)

For the time being, I suggest we remove the line and allow custom plugins. Were a build to fail because somebody checked in a conflicting configuration, I think it would either a) be an easy fix to solve it or b) not make it through the build process in the first case through returning a non-zero error code.

We should, as talked about on Slack, rethink the whole setup in q1, and I don't think it's very likely anybody would push a custom plugin before then unless it's for the same purpose we do with RN.

I'll update the readme in the CLI to reflect this.