### PR TITLE
Use target-branch as the version of stream-chat-docusaurus-cli to be installed

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         mkdir ~/.npm-global
         npm config set prefix '~/.npm-global'
         PATH=~/.npm-global/bin:$PATH
-        npm install -g https://github.com/GetStream/stream-chat-docusaurus-cli
+        npm install -g https://github.com/GetStream/stream-chat-docusaurus-cli#$TARGET_BRANCH
         stream-chat-docusaurus -i -b
       shell: bash
     - run: ${{ github.action_path }}/push.sh


### PR DESCRIPTION
Previously we were using always the `production` release to publish our docs.
With this change, depending on the target branch we want to deploy to, a different version of `stream-chat-docusaurus-cli` will be used. It allows us to iterate in our CLI and do tests on our staging environment without breaking anything on our `production` environment